### PR TITLE
Handle formatted messages & handle exceptions durring emit()

### DIFF
--- a/src/couchdblogger.py
+++ b/src/couchdblogger.py
@@ -199,7 +199,7 @@ class CouchDBLogHandler(logging.StreamHandler, object):
                             the record is emitted
         """
         return json.dumps(dict(
-            message=record.msg,
+            message=record.getMessage(),
             level=record.levelname,
             created=record.created,
             logger=record.name

--- a/src/couchdblogger.py
+++ b/src/couchdblogger.py
@@ -212,6 +212,9 @@ class CouchDBLogHandler(logging.StreamHandler, object):
         :param record: loggging record
         """
         headers = {'Content-type': 'application/json'}
-        self.session.post(self.db_url, data=self.format(record),
-            headers=headers
-        )
+        try:
+            self.session.post(self.db_url, data=self.format(record), headers=headers)
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except:
+            self.handleError(record)


### PR DESCRIPTION
*  Be able to log events that have formatted messages like ```logger.info("Test %s", "message")```
*  Handle exceptions raised during emit() with built-in ```handleError```