### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ python-couchdblogger
 [![PyPI](https://img.shields.io/pypi/dm/couchdblogger.svg)]()
 [![Requirements Status](https://requires.io/github/histrio/python-couchdblogger/requirements.svg?branch=master&style=flat)](https://requires.io/github/histrio/python-couchdblogger/requirements/?branch=master)
 
-[![Supported Python versions](https://pypip.in/py_versions/couchdblogger/badge.svg)](https://pypi.python.org/pypi/couchdblogger/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/couchdblogger.svg)](https://pypi.python.org/pypi/couchdblogger/)
 
 Simple module for logging to CouchDB. 
 Probably not best choise for logging backend, because CouchDB is not good with massive write operations. 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20couchdblogger))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `couchdblogger`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.